### PR TITLE
Task/display relative time update search

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -10,4 +10,7 @@ class Article < ActiveRecord::Base
 
   has_attached_file :image, styles: { medium: "400x500#", thumb: "250x200>" }, default_url: "missing.png"
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
+
+  include PgSearch
+  multisearchable against: [:name, :content]
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -4,4 +4,7 @@ class Category < ActiveRecord::Base
   has_and_belongs_to_many :references
 
   validates :name, presence: true, length: { minimum: 5 }
+
+  include PgSearch
+  multisearchable against: :name
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,4 +3,7 @@ class Comment < ActiveRecord::Base
   belongs_to :article, required: true
 
   validates :content, presence: true, length: { minimum: 5 }
+
+  include PgSearch
+  multisearchable against: :content
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -9,6 +9,7 @@ class Product < ActiveRecord::Base
   
   has_attached_file :image, styles: { medium: "400x500#", thumb: "250x200>" }, default_url: "missing.png"
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
+  
   include PgSearch
-  multisearchable against: [:name, :category, :description]
+  multisearchable against: [:name, :description]
 end

--- a/app/models/reference.rb
+++ b/app/models/reference.rb
@@ -5,4 +5,7 @@ class Reference < ActiveRecord::Base
 
   validates :name, presence: true, length: { minimum: 5 }
   validates :uri, presence: true, length: { minimum: 10 }
+
+  include PgSearch
+  multisearchable against: :name
 end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -6,6 +6,5 @@ class Review < ActiveRecord::Base
   validates :content, presence: true, length: { minimum: 5 }
 
   include PgSearch
-  multisearchable against: :comment
-
+  multisearchable against: :content
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,7 @@
+class Tag < ActiveRecord::Base
+  has_many :taggings
+  has_many :tags, through: :taggings
+
+  include PgSearch
+  multisearchable against: :name
+end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -10,12 +10,17 @@
     <div class="panel panel-default">
       <div class="panel-heading">
         <h2 class="panel-title-1"><%= @article.name %></h2>
-        <h4>Author: <%= @article.user.full_name %></h4>
+        
+        <h4>Author</h4>
+        <p><%= @article.user.full_name %></p>
+        
+        <h4>Created</h4>
+        <p><%= local_time_ago(@article.created_at) %></p>
+        
         <h3 class="panel-title-1">Categories</h3>
           <% @article.categories.each do |category| %>
             <%= render partial: 'categories/category_link', locals: { category: category } %>
           <% end %>
-          <br />
 
         <h3 class="panel-title-1">Tags</h3>
         <%= render @article.tags %>

--- a/app/views/comments/index.html.erb
+++ b/app/views/comments/index.html.erb
@@ -11,7 +11,10 @@
   <ul class="list-group">
     <% @article.comments.each do |comment| %>
       <li class="list-group-item">
-          <p>By <%= comment.user.full_name %> on <%= local_time(comment.created_at) %></p>
+          <p>
+            <%= comment.user.full_name %> | 
+            <%= local_time_ago(comment.created_at) %>
+          </p>
           <p><%= comment.content %></p>
           <p>
             <% if can? :update, comment %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -9,12 +9,18 @@
   <div class="col-md-6">
     <div class="panel panel-default">
       <div class="panel-heading">
-        <h2 class="panel-title-1"><%= @product.name %></h2><br />
+        <h2 class="panel-title-1"><%= @product.name %></h2>
+
+        <h4>Added By</h4>
+        <p><%= @product.user.full_name %></p>
+        
+        <h4>Created</h4>
+        <p><%= local_time_ago(@product.created_at) %></p>
+        
         <h3 class="panel-title-1">Categories</h3>
         <% @product.categories.each do |category| %>
           <%= render partial: 'categories/category_link', locals: { category: category } %>
         <% end %>
-        <br />
             
         <h3 class="panel-title-1">Tags</h3>
         <%= render @product.tags %>

--- a/app/views/references/show.html.erb
+++ b/app/views/references/show.html.erb
@@ -14,6 +14,9 @@
   <h3 class="panel-title-1">Added By</h3>
   <p><%= @reference.user.full_name %></p>
 
+  <h3 class="panel-title-1">Added On</h3>
+  <p><%= local_time_ago(@reference.created_at) %></p>
+
   <h3 class="panel-title-1">Categories</h3>
   <% @reference.categories.each do |category| %>
     <%= render partial: 'categories/category_link', locals: { category: category } %>

--- a/app/views/reviews/index.html.erb
+++ b/app/views/reviews/index.html.erb
@@ -17,7 +17,10 @@
     <% @reviews.each do |review| %>
       <li class="list-group-item">
         <div class="star-rating" data-score= <%= review.rating %> ></div>
-          <p>By <%= review.user.full_name %> on <%= local_time(review.created_at) %></p>
+          <p>
+            <%= review.user.full_name %> | 
+            <%= local_time_ago(review.created_at) %>
+          </p>
           <p><%= review.content %></p>
           <p>
             <% if can? :update, review %>

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -3,8 +3,25 @@
 <h3>  &nbsp; </h3>
 <% @pg_search_documents.each do |pgsd| %>
   <% if pgsd.searchable.class == Product %>
+    <h3>Products</h3>
     <p><%= link_to pgsd.searchable.name, pgsd.searchable %></p><hr>
   <% elsif pgsd.searchable.class == Review %>
-    <p><%= link_to pgsd.searchable.product.name %>: <%= pgsd.searchable.comment %></p><hr>
+    <h3>Product Reviews</h3>
+    <p><%= link_to pgsd.searchable.product.name %>: <%= pgsd.searchable.content %></p><hr>
+  <% elsif pgsd.searchable.class == Article %>
+    <h3>Articles</h3>
+    <p><%= link_to pgsd.searchable.name, pgsd.searchable %></p><hr>
+  <% elsif pgsd.searchable.class == Comment %>
+    <h3>Article Comments</h3>
+    <p><%= link_to pgsd.searchable.article.name %>: <%= pgsd.searchable.content %></p><hr>
+  <% elsif pgsd.searchable.class == Reference %>
+    <h3>Resources</h3>
+    <p><%= link_to pgsd.searchable.name, pgsd.searchable %></p><hr>
+  <% elsif pgsd.searchable.class == Category %>
+    <h3>Categories</h3>
+    <p><%= link_to pgsd.searchable.name, pgsd.searchable %></p><hr>
+  <% elsif pgsd.searchable.class == Tag %>
+    <h3>Tags</h3>
+    <p><%= link_to pgsd.searchable.name, pgsd.searchable %></p><hr>
   <% end %>
 <% end %>

--- a/config/initializers/pg_search.rb
+++ b/config/initializers/pg_search.rb
@@ -2,7 +2,11 @@ PgSearch.multisearch_options = {
   :using => {
     :tsearch => {
       :prefix => true,
-      :dictionary => "english"
+      :dictionary => "english",
+      :any_word => true
+    },
+    :trigram => {
+      :threshold => 0.2
     }
   }
 }

--- a/db/migrate/20160315055222_install_pg_contrib_packages.rb
+++ b/db/migrate/20160315055222_install_pg_contrib_packages.rb
@@ -1,0 +1,11 @@
+class InstallPgContribPackages < ActiveRecord::Migration
+  def up
+    execute "CREATE EXTENSION IF NOT EXISTS pg_trgm;"
+    execute "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;"
+  end
+
+  def down
+    execute "DROP EXTENSION IF EXISTS pg_trgm;"
+    execute "DROP EXTENSION IF EXISTS fuzzystrmatch;"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160310013944) do
+ActiveRecord::Schema.define(version: 20160315055222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "pg_trgm"
+  enable_extension "fuzzystrmatch"
 
   create_table "articles", force: :cascade do |t|
     t.string   "name"


### PR DESCRIPTION
@cchanningallen 
1. All created_at attributes now display as relative time ago (e.g., "yesterday at 2:58pm).
2. Updated search to include newly added models + updated search results view. Also added the PostgreSQL trigram package to allow for matching of any three-character subsets.
