### PR TITLE
Task/remove_font_awesome_gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'bootstrap-sass', '~> 3.3.6'
-gem 'font-awesome-sass'
 gem 'devise'
 gem 'responders'
 gem 'paperclip', :git=> 'https://github.com/thoughtbot/paperclip', :ref => '523bd46c768226893f23889079a7aa9c73b57d68'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,8 +131,6 @@ GEM
       railties (>= 3.0.0)
     figaro (1.1.1)
       thor (~> 0.14)
-    font-awesome-sass (4.5.0)
-      sass (>= 3.2)
     forgery (0.6.0)
     friendly_id (5.1.0)
       activerecord (>= 4.0.0)
@@ -293,7 +291,6 @@ DEPENDENCIES
   devise_zxcvbn
   factory_girl_rails (~> 4.0)
   figaro
-  font-awesome-sass
   forgery
   friendly_id (~> 5.1.0)
   jbuilder (~> 2.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,8 +2,6 @@
 @import "bootstrap_variables";
 @import "bootstrap";
 @import "bootstrap_overrides";
-@import "font-awesome-sprockets";
-@import "font-awesome";
 @import "select2";
 @import "select2-bootstrap";
 @import "forms";

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,7 @@
   <head>
     <title>The Petite Life</title>
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
+    <%= stylesheet_link_tag    'https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
   </head>


### PR DESCRIPTION
@cchanningallen CDN's don't like CORS (Cross-Origin Resource Sharing) so I removed the Font Awesome SASS gem and am now just using the [BootstrapCDN](http://fortawesome.github.io/Font-Awesome/get-started/).
